### PR TITLE
Refactor GitHub helpers

### DIFF
--- a/server/api/data.post.ts
+++ b/server/api/data.post.ts
@@ -2,6 +2,7 @@ import { readFile } from 'fs/promises'
 import { join } from 'path'
 
 import { App } from 'octokit'
+import type { Octokit } from 'octokit'
 import yaml from 'yaml'
 import type { Project } from '~/types'
 
@@ -61,7 +62,7 @@ export default defineEventHandler(async (event) => {
     )
   }
 
-  async function createBranch(owner: string, repo: string, newBranchName: string, baseBranch: string) {
+  async function createBranch(octokit: Octokit, owner: string, repo: string, newBranchName: string, baseBranch: string) {
     const { data: baseBranchData } = await octokit.rest.git.getRef({
       owner,
       repo,
@@ -76,7 +77,7 @@ export default defineEventHandler(async (event) => {
     })
   }
 
-  async function deleteOldProjectFolder(owner: string, repo: string, branch: string, oldFolderPath: string) {
+  async function deleteOldProjectFolder(octokit: Octokit, owner: string, repo: string, branch: string, oldFolderPath: string) {
     const { data: latestCommit } = await octokit.rest.repos.getCommit({
       owner,
       repo,
@@ -140,6 +141,7 @@ export default defineEventHandler(async (event) => {
   }
 
   async function commitChangesToNewBranch(
+    octokit: Octokit,
     owner: string,
     repo: string,
     newBranch: string,
@@ -209,7 +211,7 @@ export default defineEventHandler(async (event) => {
     }
   }
 
-  async function createPullRequest(owner: string, repo: string, head: string, base: string, title: string, body: string) {
+  async function createPullRequest(octokit: Octokit, owner: string, repo: string, head: string, base: string, title: string, body: string) {
     const { data: pullRequest } = await octokit.rest.pulls.create({
       owner,
       repo,
@@ -223,22 +225,23 @@ export default defineEventHandler(async (event) => {
   }
 
   try {
-    await createBranch(owner, repo, newBranchName, baseBranch)
+    await createBranch(octokit, owner, repo, newBranchName, baseBranch)
     console.log(`Branch ${newBranchName} created successfully!`)
 
     const deletedFiles = []
     if (body.project.id && body.project.id.toLowerCase() !== body.project.name.toLowerCase().replace(/\s+/g, '-')) {
       const oldId = body.project.id
       const oldFolderPath = `src/projects/${oldId}`
-      await deleteOldProjectFolder(owner, repo, newBranchName, oldFolderPath)
+      await deleteOldProjectFolder(octokit, owner, repo, newBranchName, oldFolderPath)
       console.log(`Old project folder ${oldFolderPath} deleted successfully!`)
       deletedFiles.push(oldFolderPath)
     }
 
-    await commitChangesToNewBranch(owner, repo, newBranchName, commitMessage, files, deletedFiles)
+    await commitChangesToNewBranch(octokit, owner, repo, newBranchName, commitMessage, files, deletedFiles)
     console.log(`Changes committed to branch ${newBranchName} successfully!`)
 
     const pullRequestData = await createPullRequest(
+      octokit,
       owner,
       repo,
       newBranchName,


### PR DESCRIPTION
## Summary
- use `Octokit` type for GitHub helpers
- pass `octokit` instance to helper functions

## Testing
- `pnpm lint` *(fails: Error when performing the request to https://registry.npmjs.org/pnpm/-/pnpm-9.11.0.tgz)*

------
https://chatgpt.com/codex/tasks/task_e_6847b714e2948322a7c52744d7da4d47