### PR TITLE
Replace moment with date-fns

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "@vee-validate/zod": "^4.15.0",
     "@vueuse/nuxt": "^11.0.3",
     "eslint": "^9.9.1",
-    "moment": "^2.30.1",
+    "date-fns": "^2.30.0",
     "nuxt": "^3.13.0",
     "nuxt-headlessui": "^1.2.0",
     "nuxt-lodash": "^2.5.3",

--- a/utils/text.ts
+++ b/utils/text.ts
@@ -1,7 +1,7 @@
-import moment from 'moment'
+import { format } from 'date-fns'
 
 export function formatDate(date: Date | string) {
-  return moment(date).format('MM / YYYY')
+  return format(new Date(date), 'MM / yyyy')
 }
 
 export function capitalize(word: string): string {


### PR DESCRIPTION
## Summary
- install date-fns and drop moment
- use `format` from date-fns in `utils/text.ts`

## Testing
- `pnpm test` *(fails: Error when performing the request to https://registry.npmjs.org/pnpm/-/pnpm-9.11.0.tgz)*

------
https://chatgpt.com/codex/tasks/task_e_6847b7194da88322a8e4db7a7d51511e