### PR TITLE
Add LOCAL_DATA_PATH support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+# Example environment variables for explorer-app
+# Path to a local JSON data file. If set, API will read data from this file instead of the remote source.
+LOCAL_DATA_PATH=

--- a/README.md
+++ b/README.md
@@ -23,43 +23,13 @@ If you'd like to run any tests and also manipulate the data from [explorer-data]
 3. cd /explorer-data
 4. make
 
-Then we should update our data.get.ts file in the explorer-app directory, continue the commands as following:
-
-5. cd ..
-6. cd /explorer-app
-7. cd server/api
-
-There's a file called: data.get.ts
-
-And you can replace the contents with:
-
-```
-import fs from 'fs';
-import path from 'path';
-
-export default defineEventHandler(async () => {
-  // Define the path to the local JSON file
-  const filePath = path.join('../explorer-data/dist', 'index.json');
-
-  // Read the file asynchronously
-  const data = await fs.promises.readFile(filePath, 'utf-8');
-
-  // Parse the JSON data
-  const jsonData = JSON.parse(data);
-
-  // Return the parsed JSON data
-  return jsonData;
-});
-```
-
-After which you go back to your terminal:
-
-8. cd ../../
-9. pnpm install (get [pnpm](https://pnpm.io/next/installation), npm will also work etc)
-10. pnpm run dev
+5. cd ../explorer-app
+6. cp .env.example .env # optional
+7. echo "LOCAL_DATA_PATH=../explorer-data/dist/index.json" >> .env
+8. pnpm install (get [pnpm](https://pnpm.io/next/installation), npm will also work etc)
+9. pnpm run dev
 
 Which will allow you to run both the data and the front end.
-
 
 ## Specifications
 

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -54,6 +54,7 @@ export default defineNuxtConfig({
     prefix: '_',
   },
   runtimeConfig: {
+    localDataPath: process.env.LOCAL_DATA_PATH,
     app: {
       github: {
         appId: 995628,

--- a/server/api/data.get.ts
+++ b/server/api/data.get.ts
@@ -1,3 +1,13 @@
+import { readFile } from 'fs/promises'
+import { join } from 'path'
+
 export default defineEventHandler(async () => {
+  const { localDataPath } = useRuntimeConfig()
+  if (localDataPath) {
+    const file = join(process.cwd(), localDataPath)
+    const data = await readFile(file, 'utf-8')
+    return JSON.parse(data)
+  }
+
   return $fetch('https://explorer-data.web3privacy.info/')
 })


### PR DESCRIPTION
## Summary
- add `LOCAL_DATA_PATH` runtime config
- fetch local file in `data.get` when set
- document the variable in README
- provide `.env.example`

## Testing
- `pnpm lint` *(fails: Error when performing the request to https://registry.npmjs.org/pnpm/-/pnpm-9.11.0.tgz)*
- `pnpm test` *(fails: Error when performing the request to https://registry.npmjs.org/pnpm/-/pnpm-9.11.0.tgz)*
- `pnpm typecheck` *(fails: Error when performing the request to https://registry.npmjs.org/pnpm/-/pnpm-9.11.0.tgz)*

------
https://chatgpt.com/codex/tasks/task_e_6847b71ca94883229a34cbfe6e7e867a