### PR TITLE
Fix member link handling

### DIFF
--- a/components/Project/ProjectOpenessTeamMembers.vue
+++ b/components/Project/ProjectOpenessTeamMembers.vue
@@ -6,6 +6,12 @@ const props = defineProps<{
     link?: string
   }[] | undefined
 }>()
+
+function sanitizeLink(link?: string): string {
+  if (!link)
+    return ''
+  return /^https?:\/\//.test(link) ? link : `https://${link}`
+}
 </script>
 
 <template>
@@ -31,7 +37,7 @@ const props = defineProps<{
           :key="member.name"
         >
           <NuxtLink
-            :to="member.link"
+            :to="sanitizeLink(member.link)"
             target="_blank"
             flex
             items-center


### PR DESCRIPTION
## Summary
- sanitize team member links before passing them to `<NuxtLink>`

## Testing
- `pnpm test` *(fails: Error when performing the request to https://registry.npmjs.org/pnpm/-/pnpm-9.11.0.tgz)*

------
https://chatgpt.com/codex/tasks/task_e_6847c0cc9540832289f55edb44f7f1c0