### PR TITLE
Handle anonymous teams

### DIFF
--- a/components/Project/ProjectOpeness.vue
+++ b/components/Project/ProjectOpeness.vue
@@ -313,8 +313,9 @@ defineProps<{
       </div>
     </div>
     <ProjectOpenessTeamMembers
-      v-if="project?.team?.teammembers"
+      v-if="project?.team?.anonymous || project?.team?.teammembers"
       :members="project.team?.teammembers"
+      :anonymous="project.team?.anonymous"
       mt-24px
     />
     <div mt-32px>

--- a/components/Project/ProjectOpenessMember.vue
+++ b/components/Project/ProjectOpenessMember.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-
+const props = defineProps<{ anonymous?: boolean }>()
 </script>
 
 <template>
@@ -41,18 +41,26 @@
         />
       </defs>
     </svg>
-    <div
-      flex
-      flex-col
-    >
-      <span
-        text-16px
-        font-700
-      >{{ 'Allan Scott' }}</span>
-      <span
-        text="16px app-text-grey"
-        font-400
-      >{{ 'Researcher' }}</span>
-    </div>
+      <div
+        flex
+        flex-col
+      >
+        <template v-if="props.anonymous">
+          <span
+            text-16px
+            font-700
+          >{{ 'Anonymous member' }}</span>
+        </template>
+        <template v-else>
+          <span
+            text-16px
+            font-700
+          >{{ 'Allan Scott' }}</span>
+          <span
+            text="16px app-text-grey"
+            font-400
+          >{{ 'Researcher' }}</span>
+        </template>
+      </div>
   </div>
 </template>

--- a/components/Project/ProjectOpenessTeamMembers.vue
+++ b/components/Project/ProjectOpenessTeamMembers.vue
@@ -5,6 +5,7 @@ const props = defineProps<{
     role?: string
     link?: string
   }[] | undefined
+  anonymous?: boolean
 }>()
 </script>
 
@@ -25,7 +26,13 @@ const props = defineProps<{
       md:grid-cols-3
       lg:grid-cols-4
     >
-      <template v-if="props.members?.length">
+      <template v-if="props.anonymous">
+        <span
+          text-14px
+          opacity-50
+        >{{ 'Anonymous team' }}</span>
+      </template>
+      <template v-else-if="props.members?.length">
         <template
           v-for="member in members"
           :key="member.name"


### PR DESCRIPTION
## Summary
- propagate `team.anonymous` to ProjectOpenessTeamMembers
- show anonymous placeholder when teams opt to hide members
- add anonymous support in example member component

## Testing
- `npm run lint` *(fails: command not found)*
- `npm test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6847c0dedd7083229b77fad2e54401e4