### PR TITLE
Simplify W3PN score calculation

### DIFF
--- a/components/Project/ProjectGridGroupSort.vue
+++ b/components/Project/ProjectGridGroupSort.vue
@@ -30,7 +30,7 @@ const cardTitles = ref< { label: string, sortKey: string, togglable?: boolean }[
   { label: 'Privacy', sortKey: 'privacy', togglable: true },
   { label: 'Ecosystem', sortKey: 'ecosystem' },
   { label: 'Links', sortKey: 'links' },
-  { label: 'W3PN Score', sortKey: 'score', togglable: true },
+  { label: 'Score', sortKey: 'score', togglable: true },
 ])
 
 const { width } = useWindowSize()

--- a/utils/score.test.ts
+++ b/utils/score.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest'
+import { calculateScore } from './score'
+
+describe('calculateScore', () => {
+  it('returns 100 when all criteria are met', () => {
+    const project: any = {
+      links: { github: 'a', docs: 'b' },
+      team: { members: ['Alice'] },
+      audits: [{}],
+    }
+    expect(calculateScore(project)).toBe(100)
+  })
+
+  it('uses weights for partial data', () => {
+    const project: any = {
+      links: { github: 'a' },
+      audits: [{}],
+    }
+    // github 30%, audits 20% => 50
+    expect(calculateScore(project)).toBe(50)
+  })
+})

--- a/utils/score.ts
+++ b/utils/score.ts
@@ -18,33 +18,28 @@ const fulfilled = (value: any): boolean => {
 }
 
 export const calculateScore = (project: ProjectIndexable | ProjectShallow | Project) => {
-  const criterias: { value: keyof ProjectIndexable, key: keyof ProjectIndexable | '' }[] = [
-    { value: 'product_readiness', key: '' },
-    { value: 'github', key: 'links' },
-    { value: 'docs', key: 'links' },
-    { value: 'team', key: '' },
-    { value: 'audits', key: '' },
+  const criterias: { value: keyof ProjectIndexable, key: keyof ProjectIndexable | '', weight: number }[] = [
+    { value: 'github', key: 'links', weight: 0.3 },
+    { value: 'docs', key: 'links', weight: 0.3 },
+    { value: 'team', key: '', weight: 0.2 },
+    { value: 'audits', key: '', weight: 0.2 },
   ]
 
-  let matched = 0
-  for (let i = 0; i < criterias.length; i++) {
+  let score = 0
+  for (const criteria of criterias) {
     let value
-    // value = ((criterias[i].key ?? props.project[criterias[i].value as keyof typeof props.project]) ?? null === null) ? null : (props.project as ProjectIndexable)[criterias[i].key][criterias[i].value]
-
     const indexableProject = project as ProjectIndexable
-    if (criterias[i].key !== '')
-      value = (indexableProject[criterias[i].key] as any)?.[criterias[i].value]
+    if (criteria.key !== '')
+      value = (indexableProject[criteria.key] as any)?.[criteria.value]
     else
-      value = indexableProject?.[criterias[i].value]
+      value = indexableProject?.[criteria.value]
 
-    // console.log(props.project?.links?.github);
-    // console.log(Object.keys(props.indexableProject["team"]).length);
     if (value === null || value === undefined)
       continue
 
     if (fulfilled(value))
-      matched++
+      score += criteria.weight
   }
 
-  return 100 / criterias.length * matched
+  return Math.round(score * 100)
 }


### PR DESCRIPTION
## Summary
- update scoring logic with new weights
- adjust grid label for the score column
- add unit tests for score util

## Testing
- `npx vitest run` *(fails: 403 Forbidden – cannot fetch packages)*
- `npx eslint .` *(fails: missing .nuxt/eslint.config.mjs)*

------
https://chatgpt.com/codex/tasks/task_e_6847c0e08864832282ad4c905f127c86