### PR TITLE
Allow empty score on project creation

### DIFF
--- a/server/api/data.post.ts
+++ b/server/api/data.post.ts
@@ -20,9 +20,13 @@ export default defineEventHandler(async (event) => {
     // Intentionally ignore the error
   }
 
-  const id = (body.project.id && body.project.id.toLowerCase() === body.project.name.toLowerCase().replace(/\s+/g, '-'))
+  const id = (
+    body.project.id
+    && body.project.name
+    && body.project.id.toLowerCase() === body.project.name.toLowerCase().replace(/\s+/g, '-')
+  )
     ? body.project.id
-    : body.project.name.toLowerCase().replace(/\s+/g, '-')
+    : (body.project.name ? body.project.name.toLowerCase().replace(/\s+/g, '-') : '')
 
   const yamlProject = yaml.stringify({
     ...body.project,
@@ -230,7 +234,11 @@ export default defineEventHandler(async (event) => {
     console.log(`Branch ${newBranchName} created successfully!`)
 
     const deletedFiles = []
-    if (body.project.id && body.project.id.toLowerCase() !== body.project.name.toLowerCase().replace(/\s+/g, '-')) {
+    if (
+      body.project.id
+      && body.project.name
+      && body.project.id.toLowerCase() !== body.project.name.toLowerCase().replace(/\s+/g, '-')
+    ) {
       const oldId = body.project.id
       const oldFolderPath = `src/projects/${oldId}`
       await deleteOldProjectFolder(octokit, owner, repo, newBranchName, oldFolderPath)

--- a/server/api/data.post.ts
+++ b/server/api/data.post.ts
@@ -8,7 +8,7 @@ import type { Project } from '~/types'
 import logger from '~/utils/logger'
 
 export default defineEventHandler(async (event) => {
-  const body = await readBody<{ project: Project, image?: { type: string, data: string } }>(event)
+  const body = await readBody<{ project: Partial<Project>, image?: { type: string, data: string } }>(event)
   const { appId, privateKey, installationId, baseBranch, owner, repo } = useRuntimeConfig().app.github
 
   let localPrivateKey

--- a/types/project.ts
+++ b/types/project.ts
@@ -22,7 +22,7 @@ export interface Project {
     token_link?: string
     [k: string]: unknown
   }[]
-  percentage: number
+  percentage?: number
   description?: string
   project_type?: string
   product_launch_day?: string
@@ -136,7 +136,7 @@ export interface ProjectShallow {
   image: string
   title1: string
   description: string
-  percentage: number
+  percentage?: number
   forum?: string
   github?: string
   website?: string


### PR DESCRIPTION
## Summary
- make project `percentage` optional
- make server POST API accept partial `Project` data

## Testing
- `pnpm lint` *(fails: fetch failed)*
- `pnpm typecheck` *(fails: fetch failed)*


------
https://chatgpt.com/codex/tasks/task_e_6847c0e2db2c8322b75f409b3d216749